### PR TITLE
Properly (de-)serialize dates and date-times

### DIFF
--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/IsoInstantTypeAdapter.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/IsoInstantTypeAdapter.java
@@ -1,0 +1,45 @@
+package com.jetbrains.qodana.sarif;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Reads/Writes instants as SARIF compliant strings.
+ * <a href="https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127644"/>
+ */
+final class IsoInstantTypeAdapter extends TypeAdapter<Instant> {
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .optionalStart()
+            .appendLiteral('T')
+            .append(DateTimeFormatter.ISO_TIME)
+            .optionalEnd()
+            .toFormatter();
+
+
+    @Override
+    public void write(JsonWriter out, Instant value) throws IOException {
+        ZonedDateTime utc = ZonedDateTime.ofInstant(value, ZoneId.of("UTC"));
+
+        out.value(FORMATTER.format(utc));
+    }
+
+    @Override
+    public Instant read(JsonReader in) throws IOException {
+        TemporalAccessor parsed = FORMATTER.parseBest(in.nextString(), Instant::from, LocalDate::from);
+        if (parsed instanceof Instant) {
+            return (Instant) parsed;
+        } else if (parsed instanceof LocalDate) {
+            return ((LocalDate) parsed).atStartOfDay().toInstant(ZoneOffset.UTC);
+        }
+        throw new IllegalStateException("Unreachable");
+    }
+}

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/SarifUtil.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/SarifUtil.java
@@ -22,6 +22,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -105,7 +106,8 @@ public class SarifUtil {
         return new GsonBuilder()
                 .setPrettyPrinting()
                 .disableHtmlEscaping()
-                .registerTypeAdapter(PropertyBag.class, new PropertyBag.PropertyBagTypeAdapter().nullSafe());
+                .registerTypeAdapter(PropertyBag.class, new PropertyBag.PropertyBagTypeAdapter().nullSafe())
+                .registerTypeAdapter(Instant.class, new IsoInstantTypeAdapter().nullSafe());
     }
 
     /**

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Artifact.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Artifact.java
@@ -3,6 +3,7 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Set;
 
@@ -84,7 +85,7 @@ public class Artifact {
      */
     @SerializedName("lastModifiedTimeUtc")
     @Expose
-    private Date lastModifiedTimeUtc;
+    private Instant lastModifiedTimeUtc;
     /**
      * Key/value pairs that provide additional information about the object.
      */
@@ -304,18 +305,18 @@ public class Artifact {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public Date getLastModifiedTimeUtc() {
+    public Instant getLastModifiedTimeUtc() {
         return lastModifiedTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public void setLastModifiedTimeUtc(Date lastModifiedTimeUtc) {
+    public void setLastModifiedTimeUtc(Instant lastModifiedTimeUtc) {
         this.lastModifiedTimeUtc = lastModifiedTimeUtc;
     }
 
-    public Artifact withLastModifiedTimeUtc(Date lastModifiedTimeUtc) {
+    public Artifact withLastModifiedTimeUtc(Instant lastModifiedTimeUtc) {
         this.lastModifiedTimeUtc = lastModifiedTimeUtc;
         return this;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Invocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Invocation.java
@@ -3,6 +3,7 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -37,13 +38,13 @@ public class Invocation {
      */
     @SerializedName("startTimeUtc")
     @Expose
-    private Date startTimeUtc;
+    private Instant startTimeUtc;
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation ended. See "Date/time properties" in the SARIF spec for the required format.
      */
     @SerializedName("endTimeUtc")
     @Expose
-    private Date endTimeUtc;
+    private Instant endTimeUtc;
     /**
      * The process exit code.
      */
@@ -246,18 +247,18 @@ public class Invocation {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation started. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public Date getStartTimeUtc() {
+    public Instant getStartTimeUtc() {
         return startTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation started. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public void setStartTimeUtc(Date startTimeUtc) {
+    public void setStartTimeUtc(Instant startTimeUtc) {
         this.startTimeUtc = startTimeUtc;
     }
 
-    public Invocation withStartTimeUtc(Date startTimeUtc) {
+    public Invocation withStartTimeUtc(Instant startTimeUtc) {
         this.startTimeUtc = startTimeUtc;
         return this;
     }
@@ -265,18 +266,18 @@ public class Invocation {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation ended. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public Date getEndTimeUtc() {
+    public Instant getEndTimeUtc() {
         return endTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation ended. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public void setEndTimeUtc(Date endTimeUtc) {
+    public void setEndTimeUtc(Instant endTimeUtc) {
         this.endTimeUtc = endTimeUtc;
     }
 
-    public Invocation withEndTimeUtc(Date endTimeUtc) {
+    public Invocation withEndTimeUtc(Instant endTimeUtc) {
         this.endTimeUtc = endTimeUtc;
         return this;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Notification.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Notification.java
@@ -3,6 +3,7 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class Notification {
      */
     @SerializedName("timeUtc")
     @Expose
-    private Date timeUtc;
+    private Instant timeUtc;
     /**
      * Describes a runtime exception encountered during the execution of an analysis tool.
      */
@@ -166,18 +167,18 @@ public class Notification {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.
      */
-    public Date getTimeUtc() {
+    public Instant getTimeUtc() {
         return timeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.
      */
-    public void setTimeUtc(Date timeUtc) {
+    public void setTimeUtc(Instant timeUtc) {
         this.timeUtc = timeUtc;
     }
 
-    public Notification withTimeUtc(Date timeUtc) {
+    public Notification withTimeUtc(Instant timeUtc) {
         this.timeUtc = timeUtc;
         return this;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ResultProvenance.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ResultProvenance.java
@@ -3,6 +3,7 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Set;
 
@@ -18,13 +19,13 @@ public class ResultProvenance {
      */
     @SerializedName("firstDetectionTimeUtc")
     @Expose
-    private Date firstDetectionTimeUtc;
+    private Instant firstDetectionTimeUtc;
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See "Date/time properties" in the SARIF spec for the required format.
      */
     @SerializedName("lastDetectionTimeUtc")
     @Expose
-    private Date lastDetectionTimeUtc;
+    private Instant lastDetectionTimeUtc;
     /**
      * A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.
      */
@@ -59,18 +60,18 @@ public class ResultProvenance {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was first detected. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public Date getFirstDetectionTimeUtc() {
+    public Instant getFirstDetectionTimeUtc() {
         return firstDetectionTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was first detected. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public void setFirstDetectionTimeUtc(Date firstDetectionTimeUtc) {
+    public void setFirstDetectionTimeUtc(Instant firstDetectionTimeUtc) {
         this.firstDetectionTimeUtc = firstDetectionTimeUtc;
     }
 
-    public ResultProvenance withFirstDetectionTimeUtc(Date firstDetectionTimeUtc) {
+    public ResultProvenance withFirstDetectionTimeUtc(Instant firstDetectionTimeUtc) {
         this.firstDetectionTimeUtc = firstDetectionTimeUtc;
         return this;
     }
@@ -78,18 +79,18 @@ public class ResultProvenance {
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public Date getLastDetectionTimeUtc() {
+    public Instant getLastDetectionTimeUtc() {
         return lastDetectionTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See "Date/time properties" in the SARIF spec for the required format.
      */
-    public void setLastDetectionTimeUtc(Date lastDetectionTimeUtc) {
+    public void setLastDetectionTimeUtc(Instant lastDetectionTimeUtc) {
         this.lastDetectionTimeUtc = lastDetectionTimeUtc;
     }
 
-    public ResultProvenance withLastDetectionTimeUtc(Date lastDetectionTimeUtc) {
+    public ResultProvenance withLastDetectionTimeUtc(Instant lastDetectionTimeUtc) {
         this.lastDetectionTimeUtc = lastDetectionTimeUtc;
         return this;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlowLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlowLocation.java
@@ -3,6 +3,7 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,7 +75,7 @@ public class ThreadFlowLocation {
      */
     @SerializedName("executionTimeUtc")
     @Expose
-    private Date executionTimeUtc;
+    private Instant executionTimeUtc;
     /**
      * Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is "essential", "important", "unimportant". Default: "important".
      */
@@ -274,18 +275,18 @@ public class ThreadFlowLocation {
     /**
      * The Coordinated Universal Time (UTC) date and time at which this location was executed.
      */
-    public Date getExecutionTimeUtc() {
+    public Instant getExecutionTimeUtc() {
         return executionTimeUtc;
     }
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which this location was executed.
      */
-    public void setExecutionTimeUtc(Date executionTimeUtc) {
+    public void setExecutionTimeUtc(Instant executionTimeUtc) {
         this.executionTimeUtc = executionTimeUtc;
     }
 
-    public ThreadFlowLocation withExecutionTimeUtc(Date executionTimeUtc) {
+    public ThreadFlowLocation withExecutionTimeUtc(Instant executionTimeUtc) {
         this.executionTimeUtc = executionTimeUtc;
         return this;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/VersionControlDetails.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/VersionControlDetails.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Date;
 
 
@@ -43,7 +44,7 @@ public class VersionControlDetails {
      */
     @SerializedName("asOfTimeUtc")
     @Expose
-    private Date asOfTimeUtc;
+    private Instant asOfTimeUtc;
     /**
      * Specifies the location of an artifact.
      */
@@ -152,18 +153,18 @@ public class VersionControlDetails {
     /**
      * A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.
      */
-    public Date getAsOfTimeUtc() {
+    public Instant getAsOfTimeUtc() {
         return asOfTimeUtc;
     }
 
     /**
      * A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.
      */
-    public void setAsOfTimeUtc(Date asOfTimeUtc) {
+    public void setAsOfTimeUtc(Instant asOfTimeUtc) {
         this.asOfTimeUtc = asOfTimeUtc;
     }
 
-    public VersionControlDetails withAsOfTimeUtc(Date asOfTimeUtc) {
+    public VersionControlDetails withAsOfTimeUtc(Instant asOfTimeUtc) {
         this.asOfTimeUtc = asOfTimeUtc;
         return this;
     }

--- a/sarif/src/test/java/com/jetbrains/qodana/sarif/DeserializeTest.java
+++ b/sarif/src/test/java/com/jetbrains/qodana/sarif/DeserializeTest.java
@@ -1,17 +1,14 @@
 package com.jetbrains.qodana.sarif;
 
-import com.jetbrains.qodana.sarif.model.PropertyBag;
-import com.jetbrains.qodana.sarif.model.Result;
-import com.jetbrains.qodana.sarif.model.SarifReport;
-import com.jetbrains.qodana.sarif.model.VersionedMap;
+import com.jetbrains.qodana.sarif.model.*;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,6 +51,24 @@ public class DeserializeTest {
 
         Assert.assertEquals(7, promo.size());
         Assert.assertEquals(2, sanity.size());
+    }
+
+    @Test
+    public void testDateFormat() throws IOException {
+        Path target = Paths.get("src/test/resources/testData/serializeTest/isoDates.json");
+        List<Invocation> invocations = SarifUtil.readReport(target).getRuns().get(0).getInvocations();
+
+        OffsetDateTime expect = LocalDate.of(2016, 2, 8).atStartOfDay().atOffset(ZoneOffset.UTC);
+        Assert.assertEquals(expect.toInstant(), invocations.get(0).getStartTimeUtc());
+
+        expect = expect.plusHours(16).plusMinutes(8);
+        Assert.assertEquals(expect.toInstant(), invocations.get(0).getEndTimeUtc());
+
+        expect = expect.plusSeconds(25);
+        Assert.assertEquals(expect.toInstant(), invocations.get(1).getStartTimeUtc());
+
+        expect = expect.plus(943, ChronoUnit.MILLIS);
+        Assert.assertEquals(expect.toInstant(), invocations.get(1).getEndTimeUtc());
     }
 
 

--- a/sarif/src/test/java/com/jetbrains/qodana/sarif/SerializeTest.java
+++ b/sarif/src/test/java/com/jetbrains/qodana/sarif/SerializeTest.java
@@ -10,8 +10,9 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class SerializeTest {
@@ -38,6 +39,39 @@ public class SerializeTest {
                         new Result().withPartialFingerprints(partialFingerprints)))
                 ));
         doTest(targetJson, report);
+    }
+
+    @Test
+    public void testIsoDates() throws IOException {
+        OffsetDateTime base = LocalDate.of(2016, 2, 8).atStartOfDay().atOffset(ZoneOffset.UTC);
+        Instant dayPrecision = base.toInstant();
+
+        base = base.plusHours(16).plusMinutes(8);
+        Instant minutePrecision = base.toInstant();
+
+        base = base.plusSeconds(25);
+        Instant secondPrecision = base.toInstant();
+
+        base = base.plus(943, ChronoUnit.MILLIS);
+        Instant millisPrecision = base.toInstant();
+
+        List<Invocation> invocations = List.of(
+                new Invocation().withStartTimeUtc(dayPrecision).withEndTimeUtc(minutePrecision),
+                new Invocation().withStartTimeUtc(secondPrecision).withEndTimeUtc(millisPrecision)
+        );
+
+        SarifReport before = new SarifReport().withRuns(List.of(new Run().withInvocations(invocations)));
+
+        SarifReport after;
+        // not directly comparing json here, because we will always include at least hours and minutes (spec compliant)
+        try(StringWriter w = new StringWriter()) {
+            SarifUtil.writeReport(w, before);
+
+            try(StringReader s = new StringReader(w.toString())) {
+                after = SarifUtil.readReport(s);
+            }
+        }
+        Assert.assertEquals(before, after);
     }
 
     private void doTest(String targetJson, SarifReport report) throws IOException {

--- a/sarif/src/test/resources/testData/serializeTest/isoDates.json
+++ b/sarif/src/test/resources/testData/serializeTest/isoDates.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1b01019cb217fb4ec2cba06de7572c3de92274ea18bf44a4c1514186994b882
+size 381


### PR DESCRIPTION
Internally replace java.util.Date with java.time.Instant, deprecate obsolete public API.

This change is binary compatible, so the new `Instant` based getters have to drop the `utc` suffix to not clash with the existing definition - I applied that to get/set/with for consistency