### PR TITLE
[QD-7821] Fix absent results from baseline being copied without descriptor

### DIFF
--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/BaselineCalculation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/BaselineCalculation.java
@@ -158,9 +158,13 @@ public class BaselineCalculation {
         private final Map<ResultKey, List<Result>> diffBaseline = new HashMap<>();
         private final Map<ResultKey, List<Result>> diffReport = new HashMap<>();
         private final Run report;
+        private final DescriptorLookup reportLookup;
+        private final DescriptorLookup baselineLookup;
 
         public RunResultGroup(Run report, Run baseline) {
             this.report = report;
+            this.reportLookup = new DescriptorLookup(report);
+            this.baselineLookup = new DescriptorLookup(baseline);
             buildMap(baseline, baselineHashes, diffBaseline);
             removeProblemsWithState(report, ABSENT);
             buildMap(report, reportHashes, diffReport);
@@ -238,6 +242,10 @@ public class BaselineCalculation {
                         setBaselineState(result, ABSENT);
                         absentResults++;
                         report.getResults().add(result);
+                        if (reportLookup.findById(result.getRuleId()) == null) {
+                            DescriptorWithLocation descriptor = baselineLookup.findById(result.getRuleId());
+                            if (descriptor != null) descriptor.addTo(report);
+                        }
                     }
                 } else {
                     result.setBaselineState(UNCHANGED);
@@ -263,6 +271,3 @@ public class BaselineCalculation {
         result.setBaselineState(state);
     }
 }
-
-
-

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorLookup.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorLookup.java
@@ -1,0 +1,51 @@
+package com.jetbrains.qodana.sarif.baseline;
+
+import com.jetbrains.qodana.sarif.model.ReportingDescriptor;
+import com.jetbrains.qodana.sarif.model.Run;
+import com.jetbrains.qodana.sarif.model.Tool;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+final class DescriptorLookup {
+    private final Map<String, DescriptorWithLocation> lookup;
+    private final Supplier<Stream<DescriptorWithLocation>> descriptors;
+
+    DescriptorLookup(Run run) {
+        this.lookup = new HashMap<>();
+        this.descriptors = () -> descriptors(run);
+    }
+
+    DescriptorWithLocation findById(String ruleId) {
+        // don't cache not-found results because new descriptors might be added between calls (but not removed)
+        return lookup.computeIfAbsent(ruleId, id ->
+                descriptors.get()
+                        .filter(r -> Objects.equals(r.getDescriptor().getId(), id))
+                        .findFirst()
+                        .orElse(null)
+        );
+    }
+
+    private Stream<DescriptorWithLocation> descriptors(Run run) {
+        Stream<DescriptorWithLocation> driverRules = Optional.ofNullable(run.getTool())
+                .map(Tool::getDriver)
+                .map(driver -> {
+                    Stream<ReportingDescriptor> s = driver.getRules() == null ? Stream.empty() : driver.getRules().stream();
+                    return s.map(r -> new DescriptorWithLocation(r, driver));
+                })
+                .orElseGet(Stream::empty);
+
+        Stream<DescriptorWithLocation> extRules = Optional.of(run.getTool())
+                .map(Tool::getExtensions)
+                .orElseGet(HashSet::new)
+                .stream()
+                .flatMap(extension -> {
+                    Stream<ReportingDescriptor> s = extension.getRules() == null ? Stream.empty() : extension.getRules().stream();
+                    return s.map(r -> new DescriptorWithLocation(r, extension));
+                });
+
+        return Stream.concat(driverRules, extRules);
+    }
+
+}

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorWithLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorWithLocation.java
@@ -1,0 +1,74 @@
+package com.jetbrains.qodana.sarif.baseline;
+
+import com.jetbrains.qodana.sarif.model.ReportingDescriptor;
+import com.jetbrains.qodana.sarif.model.Run;
+import com.jetbrains.qodana.sarif.model.Tool;
+import com.jetbrains.qodana.sarif.model.ToolComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+final class DescriptorWithLocation {
+    @NotNull
+    private final ReportingDescriptor descriptor;
+    @NotNull
+    private final ToolComponent location;
+
+    public DescriptorWithLocation(
+            @NotNull ReportingDescriptor descriptor,
+            @NotNull ToolComponent location) {
+        this.descriptor = descriptor;
+        this.location = location;
+    }
+
+    @NotNull
+    ReportingDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    void addTo(Run run) {
+        Tool tool = run.getTool();
+        if (tool == null) return;
+        Stream<ToolComponent> fromDriver = Optional.ofNullable(tool.getDriver())
+                .map(Stream::of)
+                .orElseGet(Stream::empty);
+
+        Stream<ToolComponent> fromExtensions = Optional.ofNullable(tool.getExtensions())
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+
+        Optional<ToolComponent> existing = Stream.concat(fromDriver, fromExtensions)
+                .filter(e -> Objects.equals(e.getFullName(), location.getFullName()) &&
+                        Objects.equals(e.getVersion(), location.getVersion())
+                )
+                .findFirst();
+
+        if (existing.isPresent()) {
+            ToolComponent e = existing.get();
+            getOrCreate(e::getRules, e::setRules, ArrayList::new)
+                    .add(descriptor);
+        } else {
+            // Collections.singletonList() is immutable
+            //noinspection ArraysAsListWithZeroOrOneArgument
+            getOrCreate(tool::getExtensions, tool::setExtensions, HashSet::new)
+                    // we don't want to copy all rules from the source AND not override them
+                    .add(location.shallowCopy()
+                            .withIsComprehensive(false)
+                            .withRules(Arrays.asList(descriptor))
+                    );
+        }
+
+    }
+
+    private <T> @NotNull T getOrCreate(Supplier<T> get, Consumer<T> set, Supplier<T> create) {
+        T value = get.get();
+        if (value != null) return value;
+        value = create.get();
+        set.accept(value);
+        return value;
+    }
+
+}

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponent.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponent.java
@@ -200,6 +200,42 @@ public class ToolComponent {
         this.name = name;
     }
 
+
+    private ToolComponent(ToolComponent that) {
+        this.guid = that.guid;
+        this.name = that.name;
+        this.organization = that.organization;
+        this.product = that.product;
+        this.productSuite = that.productSuite;
+        this.shortDescription = that.shortDescription;
+        this.fullDescription = that.fullDescription;
+        this.fullName = that.fullName;
+        this.version = that.version;
+        this.semanticVersion = that.semanticVersion;
+        this.dottedQuadFileVersion = that.dottedQuadFileVersion;
+        this.releaseDateUtc = that.releaseDateUtc;
+        this.downloadUri = that.downloadUri;
+        this.informationUri = that.informationUri;
+        this.globalMessageStrings = that.globalMessageStrings;
+        this.notifications = that.notifications;
+        this.rules = that.rules;
+        this.taxa = that.taxa;
+        this.locations = that.locations;
+        this.language = that.language;
+        this.contents = that.contents;
+        this.isComprehensive = that.isComprehensive;
+        this.localizedDataSemanticVersion = that.localizedDataSemanticVersion;
+        this.minimumRequiredLocalizedDataSemanticVersion = that.minimumRequiredLocalizedDataSemanticVersion;
+        this.associatedComponent = that.associatedComponent;
+        this.translationMetadata = that.translationMetadata;
+        this.supportedTaxonomies = that.supportedTaxonomies;
+        this.properties = that.properties;
+    }
+
+    public ToolComponent shallowCopy() {
+        return new ToolComponent(this);
+    }
+
     /**
      * A unique identifer for the tool component in the form of a GUID.
      */

--- a/sarif/src/test/resources/testData/AbsentBaselineTest/baseline.json
+++ b/sarif/src/test/resources/testData/AbsentBaselineTest/baseline.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d08b3873fe9e43e9b72ec3d742f2c5d32e536a6a4462ea8d227058e9fc680dc
+size 6093179

--- a/sarif/src/test/resources/testData/AbsentBaselineTest/baseline_old.json
+++ b/sarif/src/test/resources/testData/AbsentBaselineTest/baseline_old.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:388443f74080fa67cc772fd3face188b8235434adbf80c5e74da494ad4f1ac4d
+size 6098015

--- a/sarif/src/test/resources/testData/AbsentBaselineTest/report.json
+++ b/sarif/src/test/resources/testData/AbsentBaselineTest/report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f8d243d2fce304d038d0e268f5d93e828d4a3b8b35b0725444df56839bedb9a
+size 6094919


### PR DESCRIPTION
Descriptors will be added to existing tools if they match name and version, else a new extension is registered. All look-ups are lazy