### PR TITLE
[QD-7821] Ensure that newly generated rule lists are mutable

### DIFF
--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorWithLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorWithLocation.java
@@ -51,13 +51,11 @@ final class DescriptorWithLocation {
             getOrCreate(e::getRules, e::setRules, ArrayList::new)
                     .add(descriptor);
         } else {
-            // Collections.singletonList() is immutable
-            //noinspection ArraysAsListWithZeroOrOneArgument
             getOrCreate(tool::getExtensions, tool::setExtensions, HashSet::new)
                     // we don't want to copy all rules from the source AND not override them
                     .add(location.shallowCopy()
                             .withIsComprehensive(false)
-                            .withRules(Arrays.asList(descriptor))
+                            .withRules(new ArrayList<>(Collections.singletonList(descriptor)))
                     );
         }
 

--- a/sarif/src/test/java/com/jetbrains/qodana/sarif/BaselineTest.java
+++ b/sarif/src/test/java/com/jetbrains/qodana/sarif/BaselineTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.jetbrains.qodana.sarif.baseline.BaselineCalculation.Options.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaselineTest {
@@ -178,7 +179,7 @@ public class BaselineTest {
         SarifReport report = readReport("src/test/resources/testData/AbsentBaselineTest/report.json");
         SarifReport baseline = readReport("src/test/resources/testData/AbsentBaselineTest/baseline.json");
 
-        doTest(report, baseline, 17, 1, 1, new BaselineCalculation.Options(true));
+        doTest(report, baseline, 1, 17, 18, new BaselineCalculation.Options(true));
 
         Set<String> knownDescriptorIds = report.getRuns().stream()
                 .map(Run::getTool)
@@ -208,7 +209,7 @@ public class BaselineTest {
         SarifReport report = readReport("src/test/resources/testData/AbsentBaselineTest/report.json");
         SarifReport baseline = readReport("src/test/resources/testData/AbsentBaselineTest/baseline_old.json");
 
-        doTest(report, baseline, 17, 1, 1, new BaselineCalculation.Options(true));
+        doTest(report, baseline, 0, 18, 19, new BaselineCalculation.Options(true));
 
         Set<String> knownDescriptorIds = report.getRuns().stream()
                 .map(Run::getTool)
@@ -233,7 +234,6 @@ public class BaselineTest {
         assertEquals(new ArrayList<String>(), withoutDescriptor);
     }
 
-
     private void doTest(SarifReport report,
                         SarifReport baseline,
                         int expectedUnchanged,
@@ -242,9 +242,12 @@ public class BaselineTest {
                         BaselineCalculation.Options options
     ) {
         BaselineCalculation calculation = BaselineCalculation.compare(report, baseline, options);
-        assertEquals(expectedUnchanged, calculation.getUnchangedResults(), "Unchanged:");
-        assertEquals(expectedAbsent, calculation.getAbsentResults(), "Absent:");
-        assertEquals(expectedNew, calculation.getNewResults(), "New:");
+        assertAll(
+                () -> assertEquals(expectedUnchanged, calculation.getUnchangedResults(), "Unchanged:"),
+                () -> assertEquals(expectedAbsent, calculation.getAbsentResults(), "Absent:"),
+                () -> assertEquals(expectedNew, calculation.getNewResults(), "New:")
+        );
+
         List<Result> results = report.getRuns().get(0).getResults();
 
         if (!options.isFillBaselineState()) {
@@ -261,9 +264,11 @@ public class BaselineTest {
         List<Result> resultsUnchanged = grouped.get(Result.BaselineState.UNCHANGED);
         List<Result> resultsAbsent = grouped.get(Result.BaselineState.ABSENT);
         List<Result> resultsNew = grouped.get(Result.BaselineState.NEW);
-        assertEquals(expectedUnchanged, resultsUnchanged == null ? 0 : resultsUnchanged.size(), "Unchanged:");
-        assertEquals(expectedAbsent, resultsAbsent == null ? 0 : resultsAbsent.size(), "Absent:");
-        assertEquals(expectedNew, resultsNew == null ? 0 : resultsNew.size(), "New:");
+        assertAll(
+                () -> assertEquals(expectedUnchanged, resultsUnchanged == null ? 0 : resultsUnchanged.size(), "Unchanged:"),
+                () -> assertEquals(expectedAbsent, resultsAbsent == null ? 0 : resultsAbsent.size(), "Absent:"),
+                () -> assertEquals(expectedNew, resultsNew == null ? 0 : resultsNew.size(), "New:")
+        );
     }
 
     private void doTest(SarifReport report,

--- a/sarif/src/test/resources/testData/AbsentBaselineTest/baseline_old.json
+++ b/sarif/src/test/resources/testData/AbsentBaselineTest/baseline_old.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:388443f74080fa67cc772fd3face188b8235434adbf80c5e74da494ad4f1ac4d
-size 6098015
+oid sha256:c502da2835aa0440cb7ead5614c37cd0e4e69c2cee2f913cb283ee0352341b84
+size 6098018

--- a/sarif/src/test/resources/testData/AbsentBaselineTest/report.json
+++ b/sarif/src/test/resources/testData/AbsentBaselineTest/report.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f8d243d2fce304d038d0e268f5d93e828d4a3b8b35b0725444df56839bedb9a
-size 6094919
+oid sha256:e5b022a814d2342dd3545fd7b6a78a11f96d8f0dbbe027cd0378b464efe2d9c2
+size 6094166


### PR DESCRIPTION
While `Arrays.asList()` creates an `ArrayList`, this is NOT a `java.util.ArrayList` - and is in fact immutable.
Update the tests to catch this