### PR TITLE
Fix potential NPE in descriptor lookup

### DIFF
--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorLookup.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/baseline/DescriptorLookup.java
@@ -36,7 +36,7 @@ final class DescriptorLookup {
                 })
                 .orElseGet(Stream::empty);
 
-        Stream<DescriptorWithLocation> extRules = Optional.of(run.getTool())
+        Stream<DescriptorWithLocation> extRules = Optional.ofNullable(run.getTool())
                 .map(Tool::getExtensions)
                 .orElseGet(HashSet::new)
                 .stream()


### PR DESCRIPTION
In our existing implementation this NPE only occurs in artificial test-data, but it might also occur for other sarif producers