### PR TITLE
Introduce PropertyOwner to commonise handling of PropertyBag values

### DIFF
--- a/sarif/build.gradle.kts
+++ b/sarif/build.gradle.kts
@@ -38,6 +38,11 @@ tasks {
         }
     }
 
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.add("-Xjvm-default=all")
+        }
+    }
     withType<AbstractPublishToMaven> {
         dependsOn(test)
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Address.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Address.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).
  */
 @SuppressWarnings({"DuplicatedCode", "unused"})
-public class Address {
+public class Address implements PropertyOwner {
 
     /**
      * The address expressed as a byte offset from the start of the addressable region.
@@ -273,6 +273,7 @@ public class Address {
      * Key/value pairs that provide additional information about the object.
      */
     @SuppressWarnings("unused")
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -281,6 +282,7 @@ public class Address {
      * Key/value pairs that provide additional information about the object.
      */
     @SuppressWarnings("unused")
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Artifact.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Artifact.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * A single artifact. In some cases, this artifact might be nested within another artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Artifact {
+public class Artifact implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -323,6 +323,7 @@ public class Artifact {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -330,6 +331,7 @@ public class Artifact {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactChange.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactChange.java
@@ -10,7 +10,7 @@ import java.util.List;
  * A change to a single artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ArtifactChange {
+public class ArtifactChange implements PropertyOwner {
 
     /**
      * Specifies the location of an artifact.
@@ -94,6 +94,7 @@ public class ArtifactChange {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -101,6 +102,7 @@ public class ArtifactChange {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactContent.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactContent.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Represents the contents of an artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ArtifactContent {
+public class ArtifactContent implements PropertyOwner {
 
     /**
      * UTF-8-encoded content from a text artifact.
@@ -95,6 +95,7 @@ public class ArtifactContent {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -102,6 +103,7 @@ public class ArtifactContent {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ArtifactLocation.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Specifies the location of an artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ArtifactLocation {
+public class ArtifactLocation implements PropertyOwner {
 
     /**
      * A string containing a valid relative or absolute URI.
@@ -120,6 +120,7 @@ public class ArtifactLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -127,6 +128,7 @@ public class ArtifactLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Attachment.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Attachment.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * An artifact relevant to a result.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Attachment {
+public class Attachment implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -139,6 +139,7 @@ public class Attachment {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -146,6 +147,7 @@ public class Attachment {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/CodeFlow.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/CodeFlow.java
@@ -10,7 +10,7 @@ import java.util.List;
  * A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.
  */
 @SuppressWarnings("DuplicatedCode")
-public class CodeFlow {
+public class CodeFlow implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -90,6 +90,7 @@ public class CodeFlow {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -97,6 +98,7 @@ public class CodeFlow {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ConfigurationOverride.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ConfigurationOverride.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Information about how a specific rule or notification was reconfigured at runtime.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ConfigurationOverride {
+public class ConfigurationOverride implements PropertyOwner {
 
     /**
      * Information about a rule or notification that can be configured at runtime.
@@ -92,6 +92,7 @@ public class ConfigurationOverride {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -99,6 +100,7 @@ public class ConfigurationOverride {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Conversion.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Conversion.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Conversion {
+public class Conversion implements PropertyOwner {
 
     /**
      * The analysis tool that was run.
@@ -114,6 +114,7 @@ public class Conversion {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -121,6 +122,7 @@ public class Conversion {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Edge.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Edge.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Represents a directed edge in a graph.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Edge {
+public class Edge implements PropertyOwner {
 
     /**
      * A string that uniquely identifies the edge within its graph.
@@ -147,6 +147,7 @@ public class Edge {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -154,6 +155,7 @@ public class Edge {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/EdgeTraversal.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/EdgeTraversal.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Represents the traversal of a single edge during a graph traversal.
  */
 @SuppressWarnings("DuplicatedCode")
-public class EdgeTraversal {
+public class EdgeTraversal implements PropertyOwner {
 
     /**
      * Identifies the edge being traversed.
@@ -137,6 +137,7 @@ public class EdgeTraversal {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -144,6 +145,7 @@ public class EdgeTraversal {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Exception.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Exception.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Describes a runtime exception encountered during the execution of an analysis tool.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Exception {
+public class Exception implements PropertyOwner {
 
     /**
      * A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal.
@@ -122,6 +122,7 @@ public class Exception {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -129,6 +130,7 @@ public class Exception {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalProperties.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalProperties.java
@@ -13,7 +13,7 @@ import java.util.Set;
 /**
  * The top-level element of an external property file.
  */
-public class ExternalProperties {
+public class ExternalProperties implements PropertyOwner {
 
     /**
      * The URI of the JSON schema corresponding to the version of the external property file format.
@@ -525,6 +525,7 @@ public class ExternalProperties {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -532,6 +533,7 @@ public class ExternalProperties {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalPropertyFileReference.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalPropertyFileReference.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ExternalPropertyFileReference {
+public class ExternalPropertyFileReference implements PropertyOwner {
 
     /**
      * Specifies the location of an artifact.
@@ -95,6 +95,7 @@ public class ExternalPropertyFileReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -102,6 +103,7 @@ public class ExternalPropertyFileReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalPropertyFileReferences.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ExternalPropertyFileReferences.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * References to external property files that should be inlined with the content of a root log file.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ExternalPropertyFileReferences {
+public class ExternalPropertyFileReferences implements PropertyOwner {
 
     /**
      * Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
@@ -422,6 +422,7 @@ public class ExternalPropertyFileReferences {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -429,6 +430,7 @@ public class ExternalPropertyFileReferences {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Fix.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Fix.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Fix {
+public class Fix implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -89,6 +89,7 @@ public class Fix {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -96,6 +97,7 @@ public class Fix {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Graph.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Graph.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).
  */
 @SuppressWarnings("DuplicatedCode")
-public class Graph {
+public class Graph implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -97,6 +97,7 @@ public class Graph {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -104,6 +105,7 @@ public class Graph {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/GraphTraversal.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/GraphTraversal.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Represents a path through a graph.
  */
 @SuppressWarnings("DuplicatedCode")
-public class GraphTraversal {
+public class GraphTraversal implements PropertyOwner {
 
     /**
      * The index within the run.graphs to be associated with the result.
@@ -172,6 +172,7 @@ public class GraphTraversal {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -179,6 +180,7 @@ public class GraphTraversal {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Invocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Invocation.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * The runtime environment of the analysis tool run.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Invocation {
+public class Invocation implements PropertyOwner {
 
     /**
      * The command line used to invoke the tool.
@@ -666,6 +666,7 @@ public class Invocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -673,6 +674,7 @@ public class Invocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Location.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Location.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * A location within a programming artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Location {
+public class Location implements PropertyOwner {
 
     /**
      * Value that distinguishes this location from all other locations within a single result object.
@@ -172,6 +172,7 @@ public class Location {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -179,6 +180,7 @@ public class Location {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/LocationRelationship.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/LocationRelationship.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * Information about the relation of one location to another.
  */
 @SuppressWarnings("DuplicatedCode")
-public class LocationRelationship {
+public class LocationRelationship implements PropertyOwner {
 
     /**
      * A reference to the related location.
@@ -116,6 +116,7 @@ public class LocationRelationship {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -123,6 +124,7 @@ public class LocationRelationship {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/LogicalLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/LogicalLocation.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * A logical location of a construct that produced a result.
  */
 @SuppressWarnings("DuplicatedCode")
-public class LogicalLocation {
+public class LogicalLocation implements PropertyOwner {
 
     /**
      * Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.
@@ -170,6 +170,7 @@ public class LogicalLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -177,6 +178,7 @@ public class LogicalLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Message.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Message.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Encapsulates a message intended to be read by the end user.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Message {
+public class Message implements PropertyOwner {
 
     /**
      * A plain text message string.
@@ -122,6 +122,7 @@ public class Message {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -129,6 +130,7 @@ public class Message {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/MultiformatMessageString.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/MultiformatMessageString.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * A message string or message format string rendered in multiple formats.
  */
 @SuppressWarnings("DuplicatedCode")
-public class MultiformatMessageString {
+public class MultiformatMessageString implements PropertyOwner {
 
     /**
      * A plain text message string or format string.
@@ -87,6 +87,7 @@ public class MultiformatMessageString {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -94,6 +95,7 @@ public class MultiformatMessageString {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Node.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Node.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * Represents a node in a graph.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Node {
+public class Node implements PropertyOwner {
 
     /**
      * A string that uniquely identifies the node within its graph.
@@ -139,6 +139,7 @@ public class Node {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -146,6 +147,7 @@ public class Node {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Notification.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Notification.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Notification {
+public class Notification implements PropertyOwner {
 
     /**
      * The locations relevant to this notification.
@@ -242,6 +242,7 @@ public class Notification {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -249,6 +250,7 @@ public class Notification {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/PhysicalLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/PhysicalLocation.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class PhysicalLocation {
+public class PhysicalLocation implements PropertyOwner {
 
     /**
      * A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).
@@ -120,6 +120,7 @@ public class PhysicalLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -127,6 +128,7 @@ public class PhysicalLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/PropertyOwner.kt
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/PropertyOwner.kt
@@ -1,0 +1,15 @@
+package com.jetbrains.qodana.sarif.model
+
+interface PropertyOwner {
+    var properties: PropertyBag?
+
+    fun updateProperties(mutator: (PropertyBag) -> Unit) {
+        val props = properties ?: PropertyBag()
+        mutator(props)
+        properties = props
+    }
+}
+
+@Suppress("unused")
+fun <T: PropertyOwner> T.withUpdatedProperties(mutator: (PropertyBag) -> Unit): T =
+    apply { updateProperties(mutator) }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Rectangle.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Rectangle.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * An area within an image.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Rectangle {
+public class Rectangle implements PropertyOwner {
 
     /**
      * The Y coordinate of the top edge of the rectangle, measured in the image's natural units.
@@ -145,6 +145,7 @@ public class Rectangle {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -152,6 +153,7 @@ public class Rectangle {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Region.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Region.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * A region within an artifact where a result was detected.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Region {
+public class Region implements PropertyOwner {
 
     /**
      * The line number of the first character in the region.
@@ -295,6 +295,7 @@ public class Region {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -302,6 +303,7 @@ public class Region {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Replacement.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Replacement.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * The replacement of a single region of an artifact.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Replacement {
+public class Replacement implements PropertyOwner {
 
     /**
      * A region within an artifact where a result was detected.
@@ -87,6 +87,7 @@ public class Replacement {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -94,6 +95,7 @@ public class Replacement {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingConfiguration.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingConfiguration.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Information about a rule or notification that can be configured at runtime.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ReportingConfiguration {
+public class ReportingConfiguration implements PropertyOwner {
 
     /**
      * Specifies whether the report may be produced during the scan.
@@ -120,6 +120,7 @@ public class ReportingConfiguration {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -127,6 +128,7 @@ public class ReportingConfiguration {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptor.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptor.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ReportingDescriptor {
+public class ReportingDescriptor implements PropertyOwner {
 
     /**
      * A stable, opaque identifier for the report.
@@ -365,6 +365,7 @@ public class ReportingDescriptor {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -372,6 +373,7 @@ public class ReportingDescriptor {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptorReference.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptorReference.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Information about how to locate a relevant reporting descriptor.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ReportingDescriptorReference {
+public class ReportingDescriptorReference implements PropertyOwner {
 
     /**
      * The id of the descriptor.
@@ -120,6 +120,7 @@ public class ReportingDescriptorReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -127,6 +128,7 @@ public class ReportingDescriptorReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptorRelationship.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ReportingDescriptorRelationship.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * Information about the relation of one reporting descriptor to another.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ReportingDescriptorRelationship {
+public class ReportingDescriptorRelationship implements PropertyOwner {
 
     /**
      * Information about how to locate a relevant reporting descriptor.
@@ -116,6 +116,7 @@ public class ReportingDescriptorRelationship {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -123,6 +124,7 @@ public class ReportingDescriptorRelationship {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Result.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Result.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * A result produced by an analysis tool.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Result {
+public class Result implements PropertyOwner {
 
     /**
      * The stable, unique identifier of the rule, if any, to which this result is relevant.
@@ -771,6 +771,7 @@ public class Result {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -778,6 +779,7 @@ public class Result {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ResultProvenance.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ResultProvenance.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * Contains information about how and when a result was detected.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ResultProvenance {
+public class ResultProvenance implements PropertyOwner {
 
     /**
      * The Coordinated Universal Time (UTC) date and time at which the result was first detected. See "Date/time properties" in the SARIF spec for the required format.
@@ -173,6 +173,7 @@ public class ResultProvenance {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -180,6 +181,7 @@ public class ResultProvenance {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Run.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Run.java
@@ -10,7 +10,7 @@ import java.util.*;
  * Describes a single run of an analysis tool, and contains the reported output of that run.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Run {
+public class Run implements PropertyOwner {
 
     /**
      * The analysis tool that was run.
@@ -716,6 +716,7 @@ public class Run {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -723,6 +724,7 @@ public class Run {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/RunAutomationDetails.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/RunAutomationDetails.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Information that describes a run's identity and role within an engineering system process.
  */
 @SuppressWarnings("DuplicatedCode")
-public class RunAutomationDetails {
+public class RunAutomationDetails implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -120,6 +120,7 @@ public class RunAutomationDetails {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -127,6 +128,7 @@ public class RunAutomationDetails {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/SarifReport.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/SarifReport.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * <p>
  * Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.
  */
-public class SarifReport {
+public class SarifReport implements PropertyOwner {
 
     /**
      * The URI of the JSON schema corresponding to the version.
@@ -149,6 +149,7 @@ public class SarifReport {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -156,6 +157,7 @@ public class SarifReport {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/SpecialLocations.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/SpecialLocations.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Defines locations of special significance to SARIF consumers.
  */
 @SuppressWarnings("DuplicatedCode")
-public class SpecialLocations {
+public class SpecialLocations implements PropertyOwner {
 
     /**
      * Specifies the location of an artifact.
@@ -45,6 +45,7 @@ public class SpecialLocations {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -52,6 +53,7 @@ public class SpecialLocations {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Stack.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Stack.java
@@ -10,7 +10,7 @@ import java.util.List;
  * A call stack that is relevant to a result.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Stack {
+public class Stack implements PropertyOwner {
 
     /**
      * Encapsulates a message intended to be read by the end user.
@@ -90,6 +90,7 @@ public class Stack {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -97,6 +98,7 @@ public class Stack {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/StackFrame.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/StackFrame.java
@@ -10,7 +10,7 @@ import java.util.List;
  * A function call within a stack trace.
  */
 @SuppressWarnings("DuplicatedCode")
-public class StackFrame {
+public class StackFrame implements PropertyOwner {
 
     /**
      * A location within a programming artifact.
@@ -122,6 +122,7 @@ public class StackFrame {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -129,6 +130,7 @@ public class StackFrame {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Suppression.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Suppression.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * A suppression that is relevant to a result.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Suppression {
+public class Suppression implements PropertyOwner {
 
     /**
      * A stable, unique identifer for the suprression in the form of a GUID.
@@ -165,6 +165,7 @@ public class Suppression {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -172,6 +173,7 @@ public class Suppression {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlow.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlow.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ThreadFlow {
+public class ThreadFlow implements PropertyOwner {
 
     /**
      * An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.
@@ -165,6 +165,7 @@ public class ThreadFlow {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -172,6 +173,7 @@ public class ThreadFlow {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlowLocation.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ThreadFlowLocation.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * A location visited by an analysis tool while simulating or monitoring the execution of a program.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ThreadFlowLocation {
+public class ThreadFlowLocation implements PropertyOwner {
 
     /**
      * The index within the run threadFlowLocations array.
@@ -350,6 +350,7 @@ public class ThreadFlowLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -357,6 +358,7 @@ public class ThreadFlowLocation {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Tool.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/Tool.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * The analysis tool that was run.
  */
 @SuppressWarnings("DuplicatedCode")
-public class Tool {
+public class Tool implements PropertyOwner {
 
     /**
      * A component, such as a plug-in or the driver, of the analysis tool that was run.
@@ -89,6 +89,7 @@ public class Tool {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -96,6 +97,7 @@ public class Tool {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponent.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponent.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * A component, such as a plug-in or the driver, of the analysis tool that was run.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ToolComponent {
+public class ToolComponent implements PropertyOwner {
 
     /**
      * A unique identifer for the tool component in the form of a GUID.
@@ -754,6 +754,7 @@ public class ToolComponent {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -761,6 +762,7 @@ public class ToolComponent {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponentReference.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/ToolComponentReference.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Identifies a particular toolComponent object, either the driver or an extension.
  */
 @SuppressWarnings("DuplicatedCode")
-public class ToolComponentReference {
+public class ToolComponentReference implements PropertyOwner {
 
     /**
      * The 'name' property of the referenced toolComponent.
@@ -95,6 +95,7 @@ public class ToolComponentReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -102,6 +103,7 @@ public class ToolComponentReference {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/TranslationMetadata.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/TranslationMetadata.java
@@ -10,7 +10,7 @@ import java.net.URI;
  * Provides additional metadata related to translation.
  */
 @SuppressWarnings("DuplicatedCode")
-public class TranslationMetadata {
+public class TranslationMetadata implements PropertyOwner {
 
     /**
      * The name associated with the translation metadata.
@@ -189,6 +189,7 @@ public class TranslationMetadata {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -196,6 +197,7 @@ public class TranslationMetadata {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/VersionControlDetails.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/VersionControlDetails.java
@@ -11,7 +11,7 @@ import java.time.Instant;
  * Specifies the information necessary to retrieve a desired revision from a version control system.
  */
 @SuppressWarnings("DuplicatedCode")
-public class VersionControlDetails {
+public class VersionControlDetails implements PropertyOwner {
 
     /**
      * The absolute URI of the repository.
@@ -190,6 +190,7 @@ public class VersionControlDetails {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -197,6 +198,7 @@ public class VersionControlDetails {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/WebRequest.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/WebRequest.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Describes an HTTP request.
  */
 @SuppressWarnings("DuplicatedCode")
-public class WebRequest {
+public class WebRequest implements PropertyOwner {
 
     /**
      * The index within the run.webRequests array of the request object associated with this result.
@@ -220,6 +220,7 @@ public class WebRequest {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -227,6 +228,7 @@ public class WebRequest {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }

--- a/sarif/src/main/java/com/jetbrains/qodana/sarif/model/WebResponse.java
+++ b/sarif/src/main/java/com/jetbrains/qodana/sarif/model/WebResponse.java
@@ -3,12 +3,11 @@ package com.jetbrains.qodana.sarif.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-
 /**
  * Describes the response to an HTTP request.
  */
 @SuppressWarnings("DuplicatedCode")
-public class WebResponse {
+public class WebResponse implements PropertyOwner {
 
     /**
      * The index within the run.webResponses array of the response object associated with this result.
@@ -220,6 +219,7 @@ public class WebResponse {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public PropertyBag getProperties() {
         return properties;
     }
@@ -227,6 +227,7 @@ public class WebResponse {
     /**
      * Key/value pairs that provide additional information about the object.
      */
+    @Override
     public void setProperties(PropertyBag properties) {
         this.properties = properties;
     }


### PR DESCRIPTION
We repeat this `PropertyBag` pattern in a number of places in IJ, and ~~I just stumbled over some place where this was forgotten~~ it's very easy to forget leaing to properties being overridden on accident. 

```kotlin
fun updateProperties(mutator: (PropertyBag) -> Unit) {
  val props = properties ?: PropertyBag()
  mutator(props)
  properties = props
}
```

It's not thread-safe, but nothing is in the lib, so I didn't point it out explicitly in some doc.